### PR TITLE
fix: server tries to handle segment timeouts as responses

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -62,6 +62,10 @@ export const handler: ALBHandler = async (event: ALBEvent): Promise<ALBResult> =
         case SEGMENTS_PROXY_SEGMENT :
           logger.info("Request for HLS Proxy-Segment...");
           response = await segmentHandler(event);
+          // If response is undefined it means the request was intentionally timed out and we must not respond
+          if (!response) {
+            return;
+          }
           break;
         case DASH_PROXY_MASTER :
           logger.info("Request for DASH Proxy-Manifest...");
@@ -70,6 +74,10 @@ export const handler: ALBHandler = async (event: ALBEvent): Promise<ALBResult> =
         case DASH_PROXY_SEGMENT :
           logger.info("Request for DASH Proxy-Manifest...");
           response = await dashSegmentHandler(event);
+          // If response is undefined it means the request was intentionally timed out and we must not respond
+          if (!response) {
+            return;
+          }
         break;
         case "/" :
           logger.info("Request for Healthcheck...");

--- a/src/manifests/routes/index.ts
+++ b/src/manifests/routes/index.ts
@@ -26,7 +26,10 @@ export default async function manifestRoutes(fastify: FastifyInstance) {
   fastify.get(DASH_PROXY_SEGMENT + "/*", async (req, res) => {
     const event = composeALBEvent(req.method, req.url, req.headers);
     const response = await dashSegmentHandler(event);
-    res.code(response.statusCode).headers(response.headers).send(response.body);
+    // If response is undefined it means the request was intentionally timed out and we must not respond
+    if (response) {
+      res.code(response.statusCode).headers(response.headers).send(response.body);
+    }
   });
 
 }

--- a/src/segments/routes/index.ts
+++ b/src/segments/routes/index.ts
@@ -7,7 +7,8 @@ export default async function segmentRoutes(fastify: FastifyInstance) {
   fastify.get(SEGMENTS_PROXY_SEGMENT, async (req, res) => {
     const event = composeALBEvent(req.method, req.url, req.headers);
     const response = await segmentHandler(event);
-    if (response === undefined) {
+    // If response is undefined it means the request was intentionally timed out and we must not respond
+    if (!response) {
       return;
     }
     if (response.statusCode === 302) {


### PR DESCRIPTION
With simulated timeouts we must not respond, or they're not timeouts in the end (in this case they were converted to error code 500)