### PR TITLE
feat: Add version headers to all responses

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,7 +1,10 @@
 import { FastifyInstance } from 'fastify';
 import segmentRoutes from './segments/routes';
 import manifestRoutes from './manifests/routes';
-import { generateHeartbeatResponse } from './shared/utils';
+import {
+  generateHeartbeatResponse,
+  addCustomVersionHeader
+} from './shared/utils';
 
 const apiPrefix = (version: number): string => `api/v${version}`;
 
@@ -17,4 +20,5 @@ export function registerRoutes(app: FastifyInstance) {
   const opts = { prefix: apiPrefix(2) };
   app.register(segmentRoutes, opts);
   app.register(manifestRoutes, opts);
+  addCustomVersionHeader(app);
 }

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,0 +1,27 @@
+import fastify from 'fastify';
+import { registerRoutes } from './routes';
+import {
+  HLS_PROXY_MASTER,
+  HLS_PROXY_MEDIA,
+  SEGMENTS_PROXY_SEGMENT
+} from './segments/constants';
+
+describe('Chaos Stream Proxy server', () => {
+  let app = null;
+  beforeEach(() => {
+    app = fastify();
+    registerRoutes(app);
+  });
+
+  it.each([HLS_PROXY_MASTER, HLS_PROXY_MEDIA, SEGMENTS_PROXY_SEGMENT])(
+    'route %p contains x-version header',
+    async (route) => {
+      const response = await app.inject(route);
+      expect(response.headers).toEqual(
+        expect.objectContaining({
+          'x-version': process.env.npm_package_version
+        })
+      );
+    }
+  );
+});


### PR DESCRIPTION
The version header is dynamically updated via npm_package_version, and appended to all other existing headers. By using a Fastify hook, we ensure that the version header gets featured in every proxy response.