### PR TITLE
feat: statuscode support for compressed mpeg-dash live

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/dash/proxy-master.m
 https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/dash/proxy-master.mpd?url=https://f53accc45b7aded64ed8085068f31881.egress.mediapackage-vod.eu-north-1.amazonaws.com/out/v1/1c63bf88e2664639a6c293b4d055e6bb/64651f16da554640930b7ce2cd9f758b/66d211307b7d43d3bd515a3bfb654e1c/manifest.mpd&delay=[{i:*,ms:1500},{i:1},{i:2}]
 ```
 
+4. LIVE: Example of uncompressed MPEG-DASH live stream with response of status code 404 on segment with sequence number 3447425:
+
+```
+https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/dash/proxy-master.mpd?url=https://d2fz24s2fts31b.cloudfront.net/out/v1/3b6879c0836346c2a44c9b4b33520f4e/manifest.mpd&statusCode=[{sq:3447425, code:404}]
+```
+
+5. LIVE: Example of compressed MPEG-DASH live stream with response of status code 404 on segment with time sequence number 841164350:
+
+```
+https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/dash/proxy-master.mpd?url=https://livesim.dashif.org/livesim/testpic_2s/Manifest.mpd&statusCode=[{sq:841164350, code:404}]
+```
+
 ## Development Environment
 
 To deploy and update development environment create and push a tag with the suffix `-dev`, for example `my-feat-test-dev`. If you run `npm run deploy:dev` it will automatically create a tag based on git revision with the `-dev` suffix and push it.

--- a/src/manifests/handlers/dash/segment.ts
+++ b/src/manifests/handlers/dash/segment.ts
@@ -36,10 +36,21 @@ export default async function dashSegmentHandler(
     const urlSearchParams = new URLSearchParams(event.queryStringParameters);
     const pathStem = path.basename(event.path).replace('.mp4', '');
     // Get the number part after "segment_"
-    const [, reqSegmentIndexStr] = pathStem.split('_');
+    const [, reqSegmentIndexStr, representationIdStr, bitrateStr] =
+      pathStem.split('_');
     // Build correct Source Segment url
-    const segmentUrl = url.replace('$Number$', reqSegmentIndexStr);
+    let segmentUrl = url.replace('$Number$', reqSegmentIndexStr);
     const reqSegmentIndexInt = parseInt(reqSegmentIndexStr);
+    // Replace RepresentationID in url if present
+    if (representationIdStr) {
+      segmentUrl = segmentUrl.replace(
+        '$RepresentationID$',
+        representationIdStr
+      );
+    }
+    if (bitrateStr) {
+      urlSearchParams.set('bitrate', bitrateStr);
+    }
     // Break down Corruption Objects
     // Send source URL with a corruption json (if it is appropriate) to segmentHandler...
     const configUtils = corruptorConfigUtils(urlSearchParams);

--- a/src/manifests/utils/dashManifestUtils.test.ts
+++ b/src/manifests/utils/dashManifestUtils.test.ts
@@ -40,6 +40,40 @@ describe('dashManifestTools', () => {
       const expected: string = builder.buildObject(DASH_JSON);
       expect(proxyManifest).toEqual(expected);
     });
+
+    it('should replace initialization urls & media urls in compressed dash manifest with base urls, with absolute source url & proxy url with query parameters respectively', async () => {
+      // Arrange
+      const mockManifestPath =
+        '../../testvectors/dash/dash1_compressed/manifest.xml';
+      const mockDashManifest = fs.readFileSync(
+        path.join(__dirname, mockManifestPath),
+        'utf8'
+      );
+      const queryString =
+        'url=https://mock.mock.com/stream/manifest.mpd&statusCode=[{i:0,code:404},{i:2,code:401}]&timeout=[{i:3}]&delay=[{i:2,ms:2000}]';
+      const urlSearchParams = new URLSearchParams(queryString);
+      // Act
+      const manifestUtils = dashManifestUtils();
+      const proxyManifest: string = manifestUtils.createProxyDASHManifest(
+        mockDashManifest,
+        urlSearchParams
+      );
+      // Assert
+      const parser = new xml2js.Parser();
+      const builder = new xml2js.Builder();
+      const proxyManifestPath =
+        '../../testvectors/dash/dash1_compressed/proxy-manifest.xml';
+      const dashFile: string = fs.readFileSync(
+        path.join(__dirname, proxyManifestPath),
+        'utf8'
+      );
+      let DASH_JSON;
+      parser.parseString(dashFile, function (err, result) {
+        DASH_JSON = result;
+      });
+      const expected: string = builder.buildObject(DASH_JSON);
+      expect(proxyManifest).toEqual(expected);
+    });
   });
 });
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -171,7 +171,8 @@ export function refineALBEventQuery(
 type ProxyBasenames =
   | 'proxy-media.m3u8'
   | '../../segments/proxy-segment'
-  | 'proxy-segment/segment_$Number$.mp4';
+  | 'proxy-segment/segment_$Number$.mp4'
+  | 'proxy-segment/segment_$Number$_$RepresentationID$_$Bandwidth$';
 
 /**
  * Adjust paths based on directory navigation

--- a/src/testvectors/dash/dash1_compressed/manifest.xml
+++ b/src/testvectors/dash/dash1_compressed/manifest.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xmlns:cenc="urn:mpeg:cenc:2013"
+  xmlns:mspr="urn:microsoft:playready"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="dynamic"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  publishTime="2023-04-23T02:25:54.567928Z"
+  minimumUpdatePeriod="PT3.840S"
+  timeShiftBufferDepth="PT5M"
+  suggestedPresentationDelay="PT45S"
+  maxSegmentDuration="PT4S"
+  minBufferTime="PT10S"
+  profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014">
+  <BaseURL>relative_base/</BaseURL>
+  <Period
+    id="1"
+    start="PT0S">
+    <AdaptationSet
+      id="1"
+      group="1"
+      contentType="audio"
+      lang="no"
+      segmentAlignment="true"
+      audioSamplingRate="48000"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="48000"
+        initialization="audiotrack/init/$RepresentationID$.m4s"
+        media="audiotrack/$RepresentationID$/$Time$.m4s">
+        <SegmentTimeline>
+          <S t="80746389121167" d="184320" r="78" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="audio_track_1_1_nor=128000"
+        bandwidth="128000">
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet
+      id="2"
+      group="2"
+      contentType="video"
+      par="16:9"
+      minBandwidth="3000000"
+      maxBandwidth="3000000"
+      maxWidth="1024"
+      maxHeight="576"
+      segmentAlignment="true"
+      sar="1:1"
+      frameRate="25"
+      mimeType="video/mp4"
+      startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="600"
+        initialization="videotrack/init/$RepresentationID$.m4s"
+        media="videotrack/$RepresentationID$/$Time$.m4s">
+        <SegmentTimeline>
+          <S t="1009329864060" d="2304" r="78" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="video_track=3000000"
+        bandwidth="3000000"
+        width="1024"
+        height="576"
+        codecs="avc3.4D401F"
+        scanType="progressive">
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <UTCTiming
+    schemeIdUri="urn:mpeg:dash:utc:http-iso:2014"
+    value="https://time.akamai.com/?iso" />
+</MPD>

--- a/src/testvectors/dash/dash1_compressed/proxy-manifest.xml
+++ b/src/testvectors/dash/dash1_compressed/proxy-manifest.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xmlns:cenc="urn:mpeg:cenc:2013"
+  xmlns:mspr="urn:microsoft:playready"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="dynamic"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  publishTime="2023-04-23T02:25:54.567928Z"
+  minimumUpdatePeriod="PT3.840S"
+  timeShiftBufferDepth="PT5M"
+  suggestedPresentationDelay="PT45S"
+  maxSegmentDuration="PT4S"
+  minBufferTime="PT10S"
+  profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014">
+  <Period
+    id="1"
+    start="PT0S">
+    <AdaptationSet
+      id="1"
+      group="1"
+      contentType="audio"
+      lang="no"
+      segmentAlignment="true"
+      audioSamplingRate="48000"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="48000"
+        initialization="https://mock.mock.com/stream/relative_base/audiotrack/init/$RepresentationID$.m4s"
+        media="proxy-segment/segment_$Number$_$RepresentationID$_$Bandwidth$?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Frelative_base%2Faudiotrack%2F%24RepresentationID%24%2F%24Time%24.m4s&amp;statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&amp;timeout=%5B%7Bi%3A3%7D%5D&amp;delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D">
+        <SegmentTimeline>
+          <S t="80746389121167" d="184320" r="78" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="audio_track_1_1_nor=128000"
+        bandwidth="128000">
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet
+      id="2"
+      group="2"
+      contentType="video"
+      par="16:9"
+      minBandwidth="3000000"
+      maxBandwidth="3000000"
+      maxWidth="1024"
+      maxHeight="576"
+      segmentAlignment="true"
+      sar="1:1"
+      frameRate="25"
+      mimeType="video/mp4"
+      startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="600"
+        initialization="https://mock.mock.com/stream/relative_base/videotrack/init/$RepresentationID$.m4s"
+        media="proxy-segment/segment_$Number$_$RepresentationID$_$Bandwidth$?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Frelative_base%2Fvideotrack%2F%24RepresentationID%24%2F%24Time%24.m4s&amp;statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&amp;timeout=%5B%7Bi%3A3%7D%5D&amp;delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D">
+        <SegmentTimeline>
+          <S t="1009329864060" d="2304" r="78" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="video_track=3000000"
+        bandwidth="3000000"
+        width="1024"
+        height="576"
+        codecs="avc3.4D401F"
+        scanType="progressive">
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <UTCTiming
+    schemeIdUri="urn:mpeg:dash:utc:http-iso:2014"
+    value="https://time.akamai.com/?iso" />
+</MPD>


### PR DESCRIPTION
This is our implementation for the statusCode support for compressed MPEG-DASH live streams with manifests containing a SegmentTemplate that operates on time. Currently, our solution treats the sq-number as time, so in order to apply corruptions we have to offset it by a certain amount, relative to what it currently is.