### PR TITLE
feat: mpeg-dash relative sequence number support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ To specify the configurations for a particular corruption, you will need to add 
 Each corruption has a unique configuration JSON object template. Each object can be used to target one specific segment for corruption.
 e.i. `https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/hls/proxy-master.m3u8?url=<some_url>?some_corruption=[{i:0},{i:1},{i:2}, ... ,{i:N}]`
 
-Across all coruptions, there are 2 ways to target a segment in a playlist for corruption.
+Across all coruptions, there are 3 ways to target a segment in a playlist for corruption.
 
 1. `i`: The segment's list index in any Media Playlist, with HLS segments starting at 0 and MPEG-DASH segments starting at 1. For a Media Playlist with 12 segments, `i`=11, would target the last segment for HLS and `i`=12, would target the last segment for MPEG-DASH.
 2. `sq`: The segment's Media Sequence Number (**HLS only**). For a Media Playlist with 12 segments, and where `#EXT-X-MEDIA-SEQUENCE` is 100, `sq`=111 would target the last segment. When corrupting a live HLS stream it is recommended to target with `sq`.
+3. `rsq`: A relative sequence number, counted from where the live stream is currently at when requesting manifest. (**MPEG-DASH Live only**)
 
 Below are configuration JSON object templates for the currently supported corruptions. A query should have its value be an array consisting of any one of these 3 types of items:
 
@@ -99,6 +100,7 @@ Delay Corruption:
 {
     i?: number | "*",  // index of target segment in playlist. If "*", then target all segments. (Starts on 0 for HLS / 1 for MPEG-DASH)
     sq?: number | "*", // media sequence number of target segment in playlist. If "*", then target all segments
+    rsq?: number, // relative sequence number from where a livestream is currently at
     ms?: number,       // time to delay in milliseconds
     br?: number | "*", // apply only to specific bitrate
 }
@@ -110,6 +112,7 @@ Status Code Corruption:
 {
     i?: number | "*",  // index of target segment in playlist. If "*", then target all segments. (Starts on 0 for HLS / 1 for MPEG-DASH)
     sq?: number | "*", // media sequence number of target segment in playlist. If "*", then target all segments
+    rsq?: number, // relative sequence number from where a livestream is currently at
     code?: number,     // code to return in http response status header instead of media file
     br?: number | "*", // apply only to specific bitrate
 }
@@ -121,11 +124,14 @@ Timeout Corruption:
 {
     i?: number | "*",  // index of target segment in playlist. If "*", then target all segments. (Starts on 0 for HLS / 1 for MPEG-DASH)
     sq?: number | "*", // media sequence number of target segment in playlist. If "*", then target all segments
+    rsq?: number, // relative sequence number from where a livestream is currently at
     br?: number | "*", // apply only to specific bitrate
 }
 ```
 
-One can either target a segment through the index parameter, `i`, or the sequence number parameter, `sq`. In the case where one has entered both, the **index parameter** will take precedence.
+One can either target a segment through the index parameter, `i`, or the sequence number parameter, `sq`, relative sequence numbers, `rsq`, are translated to sequence numbers, . In the case where one has entered both, the **index parameter** will take precedence.
+
+Relative sequence numbers, `rsq`, are translated to sequence numbers, `sq`, and will thus override any provided `sq`.
 
 When targeting all segments through the input value of `"*"`, it is possible to **untarget** a specific segment by including a JSON item with only either `i` or `sq` in the corruption array, see example corruption #4.
 

--- a/src/manifests/utils/dashManifestUtils.test.ts
+++ b/src/manifests/utils/dashManifestUtils.test.ts
@@ -74,6 +74,40 @@ describe('dashManifestTools', () => {
       const expected: string = builder.buildObject(DASH_JSON);
       expect(proxyManifest).toEqual(expected);
     });
+
+    it('should replace relative sequence numbers in corruptions with absolute ones', async () => {
+      // Arrange
+      const mockManifestPath =
+        '../../testvectors/dash/dash1_relative_sequence/manifest.xml';
+      const mockDashManifest = fs.readFileSync(
+        path.join(__dirname, mockManifestPath),
+        'utf8'
+      );
+      const queryString =
+        'url=https://mock.mock.com/stream/dash/asset44/manifest.mpd&statusCode=[{rsq:10,code:404},{rsq:20,code:401}]&timeout=[{rsq:30}]&delay=[{rsq:40,ms:2000}]';
+      const urlSearchParams = new URLSearchParams(queryString);
+      // Act
+      const manifestUtils = dashManifestUtils();
+      const proxyManifest: string = manifestUtils.createProxyDASHManifest(
+        mockDashManifest,
+        urlSearchParams
+      );
+      // Assert
+      const parser = new xml2js.Parser();
+      const builder = new xml2js.Builder();
+      const proxyManifestPath =
+        '../../testvectors/dash/dash1_relative_sequence/proxy-manifest.xml';
+      const dashFile: string = fs.readFileSync(
+        path.join(__dirname, proxyManifestPath),
+        'utf8'
+      );
+      let DASH_JSON;
+      parser.parseString(dashFile, function (err, result) {
+        DASH_JSON = result;
+      });
+      const expected: string = builder.buildObject(DASH_JSON);
+      expect(proxyManifest).toEqual(expected);
+    });
   });
 });
 

--- a/src/testvectors/dash/dash1_relative_sequence/manifest.xml
+++ b/src/testvectors/dash/dash1_relative_sequence/manifest.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" id="201" type="static" mediaPresentationDuration="PT120.000S" minBufferTime="PT30S" profiles="urn:mpeg:dash:profile:isoff-main:2011">
+  <Period start="PT0.000S" id="1" duration="PT120.000S">
+    <AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1" bitstreamSwitching="true">
+      <Representation id="1" width="416" height="234" frameRate="24/1" bandwidth="99968" codecs="avc1.64000D">
+        <SegmentTemplate timescale="24000" media="../vods/asset44/index_video_1_0_$Number$.mp4" initialization="../vods/asset44/index_video_1_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation id="2" width="640" height="360" frameRate="24/1" bandwidth="229952" codecs="avc1.64001E">
+        <SegmentTemplate timescale="24000" media="../vods/asset44/index_video_2_0_$Number$.mp4" initialization="../vods/asset44/index_video_2_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation id="3" width="768" height="432" frameRate="24/1" bandwidth="329984" codecs="avc1.64001E">
+        <SegmentTemplate timescale="24000" media="../vods/asset44/index_video_3_0_$Number$.mp4" initialization="../vods/asset44/index_video_3_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation id="4" width="960" height="540" frameRate="24/1" bandwidth="520000" codecs="avc1.64001F">
+        <SegmentTemplate timescale="24000" media="../vods/asset44/index_video_4_0_$Number$.mp4" initialization="../vods/asset44/index_video_4_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4" segmentAlignment="0" lang="eng">
+      <Label>Stereo</Label>
+      <Representation id="9" bandwidth="192257" audioSamplingRate="44100" codecs="mp4a.40.2">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+        <SegmentTemplate timescale="44100" media="../vods/asset44/index_audio_9_0_$Number$.mp4" initialization="../vods/asset44/index_audio_9_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="0" d="266240"/>
+            <S t="266240" d="265215"/>
+            <S t="531455" d="264192"/>
+            <S t="795648" d="265215"/>
+            <S t="1060864" d="264191" r="1"/>
+            <S t="1589247" d="265216"/>
+            <S t="1854464" d="264191"/>
+            <S t="2118656" d="265215"/>
+            <S t="2383872" d="264191"/>
+            <S t="2648063" d="264192"/>
+            <S t="2912256" d="265215"/>
+            <S t="3177472" d="264191"/>
+            <S t="3441663" d="265215"/>
+            <S t="3706879" d="264192"/>
+            <S t="3971072" d="264191"/>
+            <S t="4235264" d="265215"/>
+            <S t="4500479" d="264192"/>
+            <S t="4764672" d="265215"/>
+            <S t="5029888" d="263167"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4" segmentAlignment="0" lang="eng">
+      <Label>Surround_aac</Label>
+      <Representation id="11" bandwidth="384810" audioSamplingRate="44100" codecs="mp4a.40.2">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="6"></AudioChannelConfiguration>
+        <SegmentTemplate timescale="44100" media="../vods/asset44/index_audio_11_0_$Number$.mp4" initialization="../vods/asset44/index_audio_11_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="0" d="266240"/>
+            <S t="266240" d="265215"/>
+            <S t="531455" d="264192"/>
+            <S t="795648" d="265215"/>
+            <S t="1060864" d="264191" r="1"/>
+            <S t="1589247" d="265216"/>
+            <S t="1854464" d="264191"/>
+            <S t="2118656" d="265215"/>
+            <S t="2383872" d="264191"/>
+            <S t="2648063" d="264192"/>
+            <S t="2912256" d="265215"/>
+            <S t="3177472" d="264191"/>
+            <S t="3441663" d="265215"/>
+            <S t="3706879" d="264192"/>
+            <S t="3971072" d="264191"/>
+            <S t="4235264" d="265215"/>
+            <S t="4500479" d="264192"/>
+            <S t="4764672" d="265215"/>
+            <S t="5029888" d="263167"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/src/testvectors/dash/dash1_relative_sequence/proxy-manifest.xml
+++ b/src/testvectors/dash/dash1_relative_sequence/proxy-manifest.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" id="201" type="static" mediaPresentationDuration="PT120.000S" minBufferTime="PT30S" profiles="urn:mpeg:dash:profile:isoff-main:2011">
+  <Period start="PT0.000S" id="1" duration="PT120.000S">
+    <AdaptationSet mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1" bitstreamSwitching="true">
+      <Representation id="1" width="416" height="234" frameRate="24/1" bandwidth="99968" codecs="avc1.64000D">
+        <SegmentTemplate timescale="24000" media="proxy-segment/segment_$Number$.mp4?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fdash%2Fvods%2Fasset44%2Findex_video_1_0_%24Number%24.mp4&amp;statusCode=%5B%7Bcode%3A404%2Csq%3A11%7D%2C%7Bcode%3A401%2Csq%3A21%7D%5D&amp;timeout=%5B%7Bsq%3A31%7D%5D&amp;delay=%5B%7Bms%3A2000%2Csq%3A41%7D%5D&amp;bitrate=99968" initialization="https://mock.mock.com/stream/dash/vods/asset44/index_video_1_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation id="2" width="640" height="360" frameRate="24/1" bandwidth="229952" codecs="avc1.64001E">
+        <SegmentTemplate timescale="24000" media="proxy-segment/segment_$Number$.mp4?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fdash%2Fvods%2Fasset44%2Findex_video_2_0_%24Number%24.mp4&amp;statusCode=%5B%7Bcode%3A404%2Csq%3A11%7D%2C%7Bcode%3A401%2Csq%3A21%7D%5D&amp;timeout=%5B%7Bsq%3A31%7D%5D&amp;delay=%5B%7Bms%3A2000%2Csq%3A41%7D%5D&amp;bitrate=229952" initialization="https://mock.mock.com/stream/dash/vods/asset44/index_video_2_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation id="3" width="768" height="432" frameRate="24/1" bandwidth="329984" codecs="avc1.64001E">
+        <SegmentTemplate timescale="24000" media="proxy-segment/segment_$Number$.mp4?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fdash%2Fvods%2Fasset44%2Findex_video_3_0_%24Number%24.mp4&amp;statusCode=%5B%7Bcode%3A404%2Csq%3A11%7D%2C%7Bcode%3A401%2Csq%3A21%7D%5D&amp;timeout=%5B%7Bsq%3A31%7D%5D&amp;delay=%5B%7Bms%3A2000%2Csq%3A41%7D%5D&amp;bitrate=329984" initialization="https://mock.mock.com/stream/dash/vods/asset44/index_video_3_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation id="4" width="960" height="540" frameRate="24/1" bandwidth="520000" codecs="avc1.64001F">
+        <SegmentTemplate timescale="24000" media="proxy-segment/segment_$Number$.mp4?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fdash%2Fvods%2Fasset44%2Findex_video_4_0_%24Number%24.mp4&amp;statusCode=%5B%7Bcode%3A404%2Csq%3A11%7D%2C%7Bcode%3A401%2Csq%3A21%7D%5D&amp;timeout=%5B%7Bsq%3A31%7D%5D&amp;delay=%5B%7Bms%3A2000%2Csq%3A41%7D%5D&amp;bitrate=520000" initialization="https://mock.mock.com/stream/dash/vods/asset44/index_video_4_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="870" d="144000" r="19"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4" segmentAlignment="0" lang="eng">
+      <Label>Stereo</Label>
+      <Representation id="9" bandwidth="192257" audioSamplingRate="44100" codecs="mp4a.40.2">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <SegmentTemplate timescale="44100" media="proxy-segment/segment_$Number$.mp4?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fdash%2Fvods%2Fasset44%2Findex_audio_9_0_%24Number%24.mp4&amp;statusCode=%5B%7Bcode%3A404%2Csq%3A11%7D%2C%7Bcode%3A401%2Csq%3A21%7D%5D&amp;timeout=%5B%7Bsq%3A31%7D%5D&amp;delay=%5B%7Bms%3A2000%2Csq%3A41%7D%5D&amp;bitrate=192257" initialization="https://mock.mock.com/stream/dash/vods/asset44/index_audio_9_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="0" d="266240"/>
+            <S t="266240" d="265215"/>
+            <S t="531455" d="264192"/>
+            <S t="795648" d="265215"/>
+            <S t="1060864" d="264191" r="1"/>
+            <S t="1589247" d="265216"/>
+            <S t="1854464" d="264191"/>
+            <S t="2118656" d="265215"/>
+            <S t="2383872" d="264191"/>
+            <S t="2648063" d="264192"/>
+            <S t="2912256" d="265215"/>
+            <S t="3177472" d="264191"/>
+            <S t="3441663" d="265215"/>
+            <S t="3706879" d="264192"/>
+            <S t="3971072" d="264191"/>
+            <S t="4235264" d="265215"/>
+            <S t="4500479" d="264192"/>
+            <S t="4764672" d="265215"/>
+            <S t="5029888" d="263167"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4" segmentAlignment="0" lang="eng">
+      <Label>Surround_aac</Label>
+      <Representation id="11" bandwidth="384810" audioSamplingRate="44100" codecs="mp4a.40.2">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="6"/>
+        <SegmentTemplate timescale="44100" media="proxy-segment/segment_$Number$.mp4?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fdash%2Fvods%2Fasset44%2Findex_audio_11_0_%24Number%24.mp4&amp;statusCode=%5B%7Bcode%3A404%2Csq%3A11%7D%2C%7Bcode%3A401%2Csq%3A21%7D%5D&amp;timeout=%5B%7Bsq%3A31%7D%5D&amp;delay=%5B%7Bms%3A2000%2Csq%3A41%7D%5D&amp;bitrate=384810" initialization="https://mock.mock.com/stream/dash/vods/asset44/index_audio_11_0_init.mp4" startNumber="1" presentationTimeOffset="0">
+          <SegmentTimeline>
+            <S t="0" d="266240"/>
+            <S t="266240" d="265215"/>
+            <S t="531455" d="264192"/>
+            <S t="795648" d="265215"/>
+            <S t="1060864" d="264191" r="1"/>
+            <S t="1589247" d="265216"/>
+            <S t="1854464" d="264191"/>
+            <S t="2118656" d="265215"/>
+            <S t="2383872" d="264191"/>
+            <S t="2648063" d="264192"/>
+            <S t="2912256" d="265215"/>
+            <S t="3177472" d="264191"/>
+            <S t="3441663" d="265215"/>
+            <S t="3706879" d="264192"/>
+            <S t="3971072" d="264191"/>
+            <S t="4235264" d="265215"/>
+            <S t="4500479" d="264192"/>
+            <S t="4764672" d="265215"/>
+            <S t="5029888" d="263167"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Location>proxy-master.mpd?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fdash%2Fasset44%2Fmanifest.mpd&amp;statusCode=%5B%7Bcode%3A404%2Csq%3A11%7D%2C%7Bcode%3A401%2Csq%3A21%7D%5D&amp;timeout=%5B%7Bsq%3A31%7D%5D&amp;delay=%5B%7Bms%3A2000%2Csq%3A41%7D%5D</Location>
+</MPD>


### PR DESCRIPTION
Add support for relative sequence numbers for mpeg-dash livestreams.

Sequence numbers are counted from where the livestream is at the moment of making the first request.