### PR TITLE
feat: Add new throttle corruption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "nock": "^13.2.4",
         "node-cache": "^5.1.2",
         "node-fetch": "^2.5.7",
+        "stream-throttle": "^0.1.3",
         "xml2js": "^0.4.19"
       },
       "devDependencies": {
@@ -34,6 +35,7 @@
         "@types/jest": "^27.4.0",
         "@types/node": "^17.0.18",
         "@types/node-fetch": "^2.5.7",
+        "@types/stream-throttle": "^0.1.1",
         "@types/xml2js": "^0.4.11",
         "@typescript-eslint/eslint-plugin": "^5.13.0",
         "@typescript-eslint/parser": "^5.13.0",
@@ -3354,6 +3356,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "node_modules/@types/stream-throttle": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@types/stream-throttle/-/stream-throttle-0.1.1.tgz",
+      "integrity": "sha512-blC1VrTJBPET4IDEpRO05L0ks7cqyyc4XBRnQVroOLkcE8iaG6MYEQ/RSU7CQ3uIGk4r7wEH0W3ifbQqCVJVAA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/xml2js": {
       "version": "0.4.11",
@@ -9806,6 +9817,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -11767,6 +11783,26 @@
       "dependencies": {
         "duplexer": "~0.1.1"
       }
+    },
+    "node_modules/stream-throttle": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha512-889+B9vN9dq7/vLbGyuHeZ6/ctf5sNuGWsDy89uNxkFTAgzy0eK7+w5fL3KLNRTkLle7EgZGvHUphZW0Q26MnQ==",
+      "dependencies": {
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
+      },
+      "bin": {
+        "throttleproxy": "bin/throttleproxy.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/stream-throttle/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -15608,6 +15644,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "@types/stream-throttle": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@types/stream-throttle/-/stream-throttle-0.1.1.tgz",
+      "integrity": "sha512-blC1VrTJBPET4IDEpRO05L0ks7cqyyc4XBRnQVroOLkcE8iaG6MYEQ/RSU7CQ3uIGk4r7wEH0W3ifbQqCVJVAA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/xml2js": {
       "version": "0.4.11",
@@ -20400,6 +20445,11 @@
       "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
       "dev": true
     },
+    "limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -21856,6 +21906,22 @@
       "dev": true,
       "requires": {
         "duplexer": "~0.1.1"
+      }
+    },
+    "stream-throttle": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha512-889+B9vN9dq7/vLbGyuHeZ6/ctf5sNuGWsDy89uNxkFTAgzy0eK7+w5fL3KLNRTkLle7EgZGvHUphZW0Q26MnQ==",
+      "requires": {
+        "commander": "^2.2.0",
+        "limiter": "^1.0.5"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "nock": "^13.2.4",
     "node-cache": "^5.1.2",
     "node-fetch": "^2.5.7",
+    "stream-throttle": "^0.1.3",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.18",
     "@types/node-fetch": "^2.5.7",
+    "@types/stream-throttle": "^0.1.1",
     "@types/xml2js": "^0.4.11",
     "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.13.0",

--- a/src/manifests/handlers/dash/segment.ts
+++ b/src/manifests/handlers/dash/segment.ts
@@ -9,6 +9,7 @@ import {
 import delaySCC from '../../utils/corruptions/delay';
 import statusCodeSCC from '../../utils/corruptions/statusCode';
 import timeoutSCC from '../../utils/corruptions/timeout';
+import throttleSCC from '../../utils/corruptions/throttle';
 import path from 'path';
 import dashManifestUtils from '../../utils/dashManifestUtils';
 import { corruptorConfigUtils } from '../../utils/configs';
@@ -54,7 +55,11 @@ export default async function dashSegmentHandler(
     // Break down Corruption Objects
     // Send source URL with a corruption json (if it is appropriate) to segmentHandler...
     const configUtils = corruptorConfigUtils(urlSearchParams);
-    configUtils.register(delaySCC).register(statusCodeSCC).register(timeoutSCC);
+    configUtils
+      .register(delaySCC)
+      .register(statusCodeSCC)
+      .register(timeoutSCC)
+      .register(throttleSCC);
     const [error, allMutations] = configUtils.getAllManifestConfigs(
       reqSegmentIndexInt,
       true

--- a/src/manifests/handlers/hls/media.ts
+++ b/src/manifests/handlers/hls/media.ts
@@ -9,6 +9,7 @@ import {
 import delaySCC from '../../utils/corruptions/delay';
 import statusCodeSCC from '../../utils/corruptions/statusCode';
 import timeoutSCC from '../../utils/corruptions/timeout';
+import throttleSCC from '../../utils/corruptions/throttle';
 import path from 'path';
 import hlsManifestUtils from '../../utils/hlsManifestUtils';
 import { corruptorConfigUtils } from '../../utils/configs';
@@ -46,7 +47,11 @@ export default async function hlsMediaHandler(
     const manifestUtils = hlsManifestUtils();
     const configUtils = corruptorConfigUtils(reqQueryParams);
 
-    configUtils.register(delaySCC).register(statusCodeSCC).register(timeoutSCC);
+    configUtils
+      .register(delaySCC)
+      .register(statusCodeSCC)
+      .register(timeoutSCC)
+      .register(throttleSCC);
 
     const [error, allMutations] = configUtils.getAllManifestConfigs(
       mediaM3U.get('mediaSequence')

--- a/src/manifests/utils/corruptions/throttle.test.ts
+++ b/src/manifests/utils/corruptions/throttle.test.ts
@@ -1,0 +1,177 @@
+import statusCodeConfig from './statusCode';
+import throttleConfig from './throttle';
+
+describe('manifest.utils.corruptions.throttle', () => {
+  describe('getManifestConfigs', () => {
+    const { getManifestConfigs, name } = throttleConfig;
+    it('should have correct name', () => {
+      // Assert
+      expect(name).toEqual('throttle');
+    });
+    it('should handle valid input', () => {
+      // Arrange
+      const throttleValue = [
+        { i: 0, rate: 1000 },
+        { i: 0, rate: 5000 },
+        { sq: 0, rate: 15000 }
+      ];
+
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        null,
+        [
+          { i: 0, fields: { rate: 1000 } },
+          { sq: 0, fields: { rate: 15000 } }
+        ]
+      ];
+
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle all * indexes', () => {
+      // Arrange
+      const throttleValue: Record<string, number | '*'>[] = [
+        { i: '*', rate: 1500 },
+        { i: 0 }
+      ];
+
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        null,
+        [
+          { i: '*', fields: { rate: 1500 } },
+          { i: 0, fields: null }
+        ]
+      ];
+
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle all * sequences', () => {
+      // Arrange
+      const throttleValue: Record<string, number | '*'>[] = [
+        { sq: '*', rate: 1500 },
+        { sq: 0 }
+      ];
+
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        null,
+        [
+          { sq: '*', fields: { rate: 1500 } },
+          { sq: 0, fields: null }
+        ]
+      ];
+
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle no index and no sequence correct', () => {
+      // Arrange
+      const throttleValue = [{ rate: 1500 }];
+
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        {
+          message:
+            "Incorrect throttle query format. Either 'i' or 'sq' is required in a single query object.",
+          status: 400
+        },
+        null
+      ];
+
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle both index and sequence in the query object', () => {
+      // Arrange
+      const throttleValue = [{ rate: 1500, i: 0, sq: 2 }];
+
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        {
+          message:
+            "Incorrect throttle query format. 'i' and 'sq' are mutually exclusive in a single query object.",
+          status: 400
+        },
+        null
+      ];
+
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle illegal characters in query object', () => {
+      // Arrange
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const throttleValue = [{ rate: 'hehe', i: false, sq: { he: 'he' } }] as any;
+
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        {
+          message:
+            'Incorrect throttle query format. Expected format: [{i?:number, sq?:number, br?:number, rate:number}, ...n] where i and sq are mutually exclusive.',
+          status: 400
+        },
+        null
+      ];
+
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle invalid format', () => {
+      // Arrange
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const throttleValue = 'Faulty' as any;
+
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        {
+          message:
+            'Incorrect throttle query format. Expected format: [{i?:number, sq?:number, br?:number, rate:number}, ...n] where i and sq are mutually exclusive.',
+          status: 400
+        },
+        null
+      ];
+
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle multiple defaults *', () => {
+      // Arrange
+      const throttleValue: Record<string, number | '*'>[] = [
+        { rate: 1000, i: '*' },
+        { rate: 5000, sq: '*' },
+        { rate: 10000, i: '*' }
+      ];
+      // Act
+      const actual = getManifestConfigs(throttleValue);
+      const expected = [
+        null,
+        [
+          {
+            fields: {
+              rate: 1000
+            },
+            i: '*'
+          }
+        ]
+      ];
+      // Assert
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/src/manifests/utils/corruptions/throttle.test.ts
+++ b/src/manifests/utils/corruptions/throttle.test.ts
@@ -1,4 +1,3 @@
-import statusCodeConfig from './statusCode';
 import throttleConfig from './throttle';
 
 describe('manifest.utils.corruptions.throttle', () => {
@@ -113,7 +112,9 @@ describe('manifest.utils.corruptions.throttle', () => {
     it('should handle illegal characters in query object', () => {
       // Arrange
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const throttleValue = [{ rate: 'hehe', i: false, sq: { he: 'he' } }] as any;
+      const throttleValue = [
+        { rate: 'hehe', i: false, sq: { he: 'he' } }
+      ] as any;
 
       // Act
       const actual = getManifestConfigs(throttleValue);

--- a/src/manifests/utils/corruptions/throttle.ts
+++ b/src/manifests/utils/corruptions/throttle.ts
@@ -1,0 +1,142 @@
+import { unparsableError } from '../../../shared/utils';
+import { ServiceError, TargetIndex } from '../../../shared/types';
+import { CorruptorConfig, SegmentCorruptorQueryConfig } from '../configs';
+
+interface ThrottleConfig extends CorruptorConfig {
+  i?: TargetIndex;
+  sq?: TargetIndex;
+  br?: TargetIndex;
+  rate?: number;
+}
+
+// TODO:Flytta till en i en constants fil, och gruppera med and
+const throttleExpectedQueryFormatMsg =
+  'Incorrect throttle query format. Expected format: [{i?:number, sq?:number, br?:number, rate:number}, ...n] where i and sq are mutually exclusive.';
+
+function getManifestConfigError(value: { [key: string]: unknown }): string {
+  const o = value as ThrottleConfig;
+
+  if (o.rate && typeof o.rate !== 'number') {
+    return throttleExpectedQueryFormatMsg;
+  }
+
+  if (o.i === undefined && o.sq === undefined) {
+    return "Incorrect throttle query format. Either 'i' or 'sq' is required in a single query object.";
+  }
+
+  if (
+    !(o.i === '*' || typeof o.i === 'number') &&
+    !(o.sq === '*' || typeof o.sq === 'number')
+  ) {
+    return throttleExpectedQueryFormatMsg;
+  }
+
+  if (o.i !== undefined && o.sq !== undefined) {
+    return "Incorrect throttle query format. 'i' and 'sq' are mutually exclusive in a single query object.";
+  }
+
+  if (Number(o.sq) < 0) {
+    return 'Incorrect throttle query format. Field sq must be 0 or positive.';
+  }
+
+  if (Number(o.i) < 0) {
+    return 'Incorrect throttle query format. Field i must be 0 or positive.';
+  }
+
+  return '';
+}
+function isValidSegmentConfig(value: { [key: string]: unknown }): boolean {
+  if (value.rate && typeof value.rate !== 'number') {
+    return false;
+  }
+  return true;
+}
+
+const throttleConfig: SegmentCorruptorQueryConfig = {
+  getManifestConfigs(
+    configs: Record<string, TargetIndex>[]
+  ): [ServiceError | null, CorruptorConfig[] | null] {
+    // Verify it's at least an array
+    if (!Array.isArray(configs)) {
+      return [
+        {
+          message: throttleExpectedQueryFormatMsg,
+          status: 400
+        },
+        null
+      ];
+    }
+
+    const configIndexMap = new Map<TargetIndex, CorruptorConfig>();
+    const configSqMap = new Map<TargetIndex, CorruptorConfig>();
+
+    for (const config of configs) {
+      // Verify integrity of array content
+      const error = getManifestConfigError(config);
+      if (error) {
+        return [{ message: error, status: 400 }, null];
+      }
+
+      const { rate, i, sq } = config;
+      const fields = rate ? { rate } : null;
+
+      // If * is already set, we skip
+      if (!configIndexMap.has('*') && !configSqMap.has('*')) {
+        // Index
+        if (i === '*') {
+          configIndexMap.set('*', { fields, i });
+        }
+        // Sequence
+        else if (sq === '*') {
+          configSqMap.set('*', { fields, sq });
+        }
+      }
+
+      // Index numeric
+      if (typeof i === 'number' && !configIndexMap.has(i)) {
+        configIndexMap.set(i, { fields, i });
+      }
+
+      // Sequence numeric
+      if (typeof sq === 'number' && !configSqMap.has(sq)) {
+        configSqMap.set(sq, { fields, sq });
+      }
+    }
+
+    const corruptorConfigs = [
+      ...configIndexMap.values(),
+      ...configSqMap.values()
+    ];
+
+    return [null, corruptorConfigs];
+  },
+  getSegmentConfigs(
+    throttleConfigString: string
+  ): [ServiceError | null, CorruptorConfig | null] {
+    const config = JSON.parse(throttleConfigString);
+    if (!isValidSegmentConfig(config)) {
+      return [
+        unparsableError(
+          'throttle',
+          throttleConfigString,
+          '{i?:number, sq?:number, rate:number}'
+        ),
+        null
+      ];
+    }
+
+    return [
+      null,
+      {
+        i: config.i,
+        sq: config.sq,
+        fields: {
+          rate: config.rate
+        }
+      }
+    ];
+  },
+  name: 'throttle'
+};
+
+export default throttleConfig;

--- a/src/manifests/utils/dashManifestUtils.ts
+++ b/src/manifests/utils/dashManifestUtils.ts
@@ -209,7 +209,7 @@ function convertRelativeToAbsoluteSegmentOffsets(
 
   const urlQuery = new URLSearchParams(originalUrlQuery);
 
-  const corruptions = ['statusCode', 'delay', 'timeout'];
+  const corruptions = ['statusCode', 'delay', 'timeout', 'throttle'];
 
   let changed = false;
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,6 +5,7 @@ import {
   generateHeartbeatResponse,
   addCustomVersionHeader
 } from './shared/utils';
+import throttlingProxyRoutes from './segments/routes/throttlingProxy';
 
 const apiPrefix = (version: number): string => `api/v${version}`;
 
@@ -20,5 +21,6 @@ export function registerRoutes(app: FastifyInstance) {
   const opts = { prefix: apiPrefix(2) };
   app.register(segmentRoutes, opts);
   app.register(manifestRoutes, opts);
+  app.register(throttlingProxyRoutes, opts);
   addCustomVersionHeader(app);
 }

--- a/src/segments/constants.ts
+++ b/src/segments/constants.ts
@@ -9,3 +9,4 @@ export const HLS_PROXY_MEDIA = '/manifests/hls/proxy-media.m3u8';
 export const SEGMENTS_PROXY_SEGMENT = '/segments/proxy-segment';
 export const DASH_PROXY_MASTER = '/manifests/dash/proxy-master.mpd';
 export const DASH_PROXY_SEGMENT = '/manifests/dash/proxy-segment';
+export const THROTTLING_PROXY = '/throttle';

--- a/src/segments/routes/throttlingProxy.ts
+++ b/src/segments/routes/throttlingProxy.ts
@@ -1,0 +1,33 @@
+import { FastifyInstance } from 'fastify';
+import { composeALBEvent } from '../../shared/utils';
+import { THROTTLING_PROXY } from '../constants';
+import fetch from 'node-fetch';
+import { Throttle } from 'stream-throttle';
+
+export default async function throttlingProxyRoutes(fastify: FastifyInstance) {
+  fastify.get(THROTTLING_PROXY, async (req, res) => {
+    const event = await composeALBEvent(req.method, req.url, req.headers);
+
+    const query = event.queryStringParameters;
+    if (!query) {
+      res.code(501);
+      return;
+    }
+    const url = query['url'];
+    const rate = Number(query['rate']);
+
+    const middle = await fetch(url);
+    if (middle.status != 200) {
+      res.code(500).send('Invalid return code for segment from remote');
+    }
+
+    const headers = {};
+    middle.headers.forEach((v, k) => {
+      headers[k] = v;
+    });
+
+    const throttle = new Throttle({ rate });
+
+    res.code(middle.status).headers(headers).send(middle.body.pipe(throttle));
+  });
+}

--- a/src/shared/aws.utils.ts
+++ b/src/shared/aws.utils.ts
@@ -40,6 +40,7 @@ export function addSSMUrlParametersToUrl(url: string): Promise<string> {
     !url.includes('delay') &&
     !url.includes('statusCode') &&
     !url.includes('timeout') &&
+    !url.includes('throttle') &&
     url.includes('proxy-master')
   ) {
     const parameterName =


### PR DESCRIPTION
* Add new throttling corruption for media segments. `throttle={sq: *, rate: 1000}`
  * Throttling is specified in bytes per second.
  * Segment is kept in memory on the proxy and fed in chunks back to the client.