### PR TITLE
feat: relative sequence support for HLS using optional stateful mode

### DIFF
--- a/src/manifests/handlers/hls/master.ts
+++ b/src/manifests/handlers/hls/master.ts
@@ -5,7 +5,9 @@ import {
   isValidUrl,
   parseM3U8Text,
   refineALBEventQuery,
-  generateErrorResponse
+  generateErrorResponse,
+  STATEFUL,
+  newState
 } from '../../../shared/utils';
 
 // To be able to reuse the handlers for AWS lambda function - input should be ALBEvent
@@ -40,11 +42,16 @@ export default async function hlsMasterHandler(event: ALBEvent) {
       });
     }
 
+    const stateKey = STATEFUL
+      ? newState({ initialSequenceNumber: undefined })
+      : undefined;
+
     const reqQueryParams = new URLSearchParams(query);
     const manifestUtils = hlsManifestUtils();
     const proxyManifest = manifestUtils.createProxyMasterManifest(
       masterM3U,
-      reqQueryParams
+      reqQueryParams,
+      stateKey
     );
 
     return {

--- a/src/manifests/handlers/hls/media.test.ts
+++ b/src/manifests/handlers/hls/media.test.ts
@@ -245,6 +245,136 @@ https://mock.mock.com/stream/hls/manifest_1_00001.ts
       expect(response.body).toEqual(expected.body);
     });
 
+    it('should return 400 when providing relative offset in stateless mode', async () => {
+      // Arrange
+      const getMedia = () => {
+        return new Promise((resolve) => {
+          const readStream: ReadStream = createReadStream(
+            path.join(
+              __dirname,
+              `../../../testvectors/hls/hls2_multitrack/manifest_1.m3u8`
+            )
+          );
+          resolve(readStream);
+        });
+      };
+      nock(mockBaseURL).persist().get('/manifest_1.m3u8').reply(200, getMedia, {
+        'Content-Type': 'application/vnd.apple.mpegurl;charset=UTF-8',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type, Origin'
+      });
+
+      const queryParams = {
+        url: mockMediaURL,
+        statusCode: '[{rsq:15,code:400}]'
+      };
+      const event: ALBEvent = {
+        requestContext: {
+          elb: {
+            targetGroupArn: ''
+          }
+        },
+        path: '/stream/hls/manifest.m3u8',
+        httpMethod: 'GET',
+        headers: {
+          accept: 'application/vnd.apple.mpegurl;charset=UTF-8',
+          'accept-language': 'en-US,en;q=0.8',
+          'content-type': 'text/plain',
+          host: 'lambda-846800462-us-east-2.elb.amazonaws.com',
+          'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)',
+          'x-amzn-trace-id': 'Root=1-5bdb40ca-556d8b0c50dc66f0511bf520',
+          'x-forwarded-for': '72.21.198.xx',
+          'x-forwarded-port': '443',
+          'x-forwarded-proto': 'https'
+        },
+        isBase64Encoded: false,
+        queryStringParameters: queryParams,
+        body: ''
+      };
+
+      // Act
+      const response = await hlsMediaHandler(event);
+
+      // Assert
+      const expected: ALBResult = {
+        statusCode: 400,
+        headers: {
+          'Access-Control-Allow-Headers': 'Content-Type, Origin',
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'application/json'
+        },
+        body: '{"reason":"Relative sequence numbers on HLS are only supported when proxy is running in stateful mode"}'
+      };
+      expect(response.statusCode).toEqual(expected.statusCode);
+      expect(response.headers).toEqual(expected.headers);
+      expect(response.body).toEqual(expected.body);
+    });
+
+    it('should return 400 when providing relative offset in stateless mode', async () => {
+      // Arrange
+      const getMedia = () => {
+        return new Promise((resolve) => {
+          const readStream: ReadStream = createReadStream(
+            path.join(
+              __dirname,
+              `../../../testvectors/hls/hls2_multitrack/manifest_1.m3u8`
+            )
+          );
+          resolve(readStream);
+        });
+      };
+      nock(mockBaseURL).persist().get('/manifest_1.m3u8').reply(200, getMedia, {
+        'Content-Type': 'application/vnd.apple.mpegurl;charset=UTF-8',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type, Origin'
+      });
+
+      const queryParams = {
+        url: mockMediaURL,
+        statusCode: '[{rsq:15,code:400}]'
+      };
+      const event: ALBEvent = {
+        requestContext: {
+          elb: {
+            targetGroupArn: ''
+          }
+        },
+        path: '/stream/hls/manifest.m3u8',
+        httpMethod: 'GET',
+        headers: {
+          accept: 'application/vnd.apple.mpegurl;charset=UTF-8',
+          'accept-language': 'en-US,en;q=0.8',
+          'content-type': 'text/plain',
+          host: 'lambda-846800462-us-east-2.elb.amazonaws.com',
+          'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)',
+          'x-amzn-trace-id': 'Root=1-5bdb40ca-556d8b0c50dc66f0511bf520',
+          'x-forwarded-for': '72.21.198.xx',
+          'x-forwarded-port': '443',
+          'x-forwarded-proto': 'https'
+        },
+        isBase64Encoded: false,
+        queryStringParameters: queryParams,
+        body: ''
+      };
+
+      // Act
+      const response = await hlsMediaHandler(event);
+
+      // Assert
+      const expected: ALBResult = {
+        statusCode: 400,
+        headers: {
+          'Access-Control-Allow-Headers': 'Content-Type, Origin',
+          'Access-Control-Allow-Origin': '*',
+          'Content-Type': 'application/json'
+        },
+        body: '{"reason":"Relative sequence numbers on HLS are only supported when proxy is running in stateful mode"}'
+      };
+      expect(response.statusCode).toEqual(expected.statusCode);
+      expect(response.headers).toEqual(expected.headers);
+      expect(response.body).toEqual(expected.body);
+    });
+
     //it('should return code 500 on Other Errors, eg M3U8 parser error', async () => {});
   });
 });

--- a/src/manifests/utils/configs.test.ts
+++ b/src/manifests/utils/configs.test.ts
@@ -173,46 +173,52 @@ describe('configs', () => {
       expect(actualLevel).toEqual(expectedLevel);
     });
 
-    it('should handle media sequence offsets', () => {
-      // Arrange
-      process.env.STATEFUL = 'true';
+    describe('in stateful mode', () => {
+      let statefulConfig;
+      beforeAll(() => {
+        process.env.STATEFUL = 'true';
+        statefulConfig = require('./configs');
+      });
 
-      const configs = corruptorConfigUtils(
-        new URLSearchParams(
-          'statusCode=[{rsq:15,code:400}]&throttle=[{sq:15,rate:1000}]'
-        )
-      );
+      it('should handle media sequence offsets', () => {
+        // Arrange
+        const configs = statefulConfig.corruptorConfigUtils(
+          new URLSearchParams(
+            'statusCode=[{rsq:15,code:400}]&throttle=[{sq:15,rate:1000}]'
+          )
+        );
 
-      configs.register(statusCodeConfig).register(throttleConfig);
+        configs.register(statusCodeConfig).register(throttleConfig);
 
-      // Act
+        // Act
 
-      const [err, actual] = configs.getAllManifestConfigs(0, false, 100);
+        const [err, actual] = configs.getAllManifestConfigs(0, false, 100);
 
-      // Assert
-      expect(err).toBeNull();
-      expect(actual.get(115)).toEqual(
-        new Map([
-          [
-            'statusCode',
-            {
-              fields: { code: 400 },
-              sq: 115
-            }
-          ]
-        ])
-      );
-      expect(actual.get(15)).toEqual(
-        new Map([
-          [
-            'throttle',
-            {
-              fields: { rate: 1000 },
-              sq: 15
-            }
-          ]
-        ])
-      );
+        // Assert
+        expect(err).toBeNull();
+        expect(actual.get(115)).toEqual(
+          new Map([
+            [
+              'statusCode',
+              {
+                fields: { code: 400 },
+                sq: 115
+              }
+            ]
+          ])
+        );
+        expect(actual.get(15)).toEqual(
+          new Map([
+            [
+              'throttle',
+              {
+                fields: { rate: 1000 },
+                sq: 15
+              }
+            ]
+          ])
+        );
+      });
     });
   });
 

--- a/src/manifests/utils/configs.test.ts
+++ b/src/manifests/utils/configs.test.ts
@@ -5,6 +5,8 @@ import {
   CorruptorIndexMap,
   CorruptorLevelMap
 } from './configs';
+import statusCodeConfig from './corruptions/statusCode';
+import throttleConfig from './corruptions/throttle';
 
 describe('configs', () => {
   describe('utils', () => {
@@ -87,6 +89,16 @@ describe('configs', () => {
   });
 
   describe('getAllManifestConfigs', () => {
+    const env = process.env;
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...env };
+    });
+
+    afterEach(() => {
+      process.env = env;
+    });
+
     it('should handle matching config with url query params', () => {
       // Arrange
       const configs = corruptorConfigUtils(
@@ -159,6 +171,48 @@ describe('configs', () => {
       expect(err).toBeNull();
       expect(actualIndex).toEqual(expectedIndex);
       expect(actualLevel).toEqual(expectedLevel);
+    });
+
+    it('should handle media sequence offsets', () => {
+      // Arrange
+      process.env.STATEFUL = 'true';
+
+      const configs = corruptorConfigUtils(
+        new URLSearchParams(
+          'statusCode=[{rsq:15,code:400}]&throttle=[{sq:15,rate:1000}]'
+        )
+      );
+
+      configs.register(statusCodeConfig).register(throttleConfig);
+
+      // Act
+
+      const [err, actual] = configs.getAllManifestConfigs(0, false, 100);
+
+      // Assert
+      expect(err).toBeNull();
+      expect(actual.get(115)).toEqual(
+        new Map([
+          [
+            'statusCode',
+            {
+              fields: { code: 400 },
+              sq: 115
+            }
+          ]
+        ])
+      );
+      expect(actual.get(15)).toEqual(
+        new Map([
+          [
+            'throttle',
+            {
+              fields: { rate: 1000 },
+              sq: 15
+            }
+          ]
+        ])
+      );
     });
   });
 

--- a/src/manifests/utils/hlsManifestUtils.test.ts
+++ b/src/manifests/utils/hlsManifestUtils.test.ts
@@ -30,7 +30,8 @@ describe('hlsManifestTools', () => {
       const manifestUtils = hlsManifestUtils();
       const proxyManifest: string = manifestUtils.createProxyMasterManifest(
         masterM3U,
-        urlSearchParams
+        urlSearchParams,
+        undefined
       );
 
       // Assert


### PR DESCRIPTION
Support for relative sequence number for HLS livestreams using optional stateful mode, keeping first media sequence number in memory.
Configurable TTL.