### PR TITLE
fix: Optional uri paramenter was required for ext-x-media

### DIFF
--- a/src/manifests/utils/hlsManifestUtils.ts
+++ b/src/manifests/utils/hlsManifestUtils.ts
@@ -102,6 +102,11 @@ export default function (): HLSManifestTools {
       // [Audio/Subtitles/IFrame]
       m3u.items.MediaItem = m3u.items.MediaItem.map((mediaItem) => {
         const currentUri = mediaItem.get('uri');
+        // #EXT-X-MEDIA URI,is only required with type SUBTITLES, optional for AUDIO and VIDEO
+        if (mediaItem.get('type') !== 'SUBTITLES' && currentUri == undefined) {
+          return mediaItem;
+        }
+
         mediaItem.set(
           'uri',
           proxyPathBuilder(currentUri, originalUrlQuery, 'proxy-media.m3u8')

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,7 +15,7 @@ export type TargetIndex = number | '*';
 
 /* eslint-disable */
 export type M3UItem = {
-  get: (key: 'uri') => string | any;
+  get: (key: 'uri' | 'type') => string | any;
   set: (key: 'uri', value: string) => void;
 };
 


### PR DESCRIPTION
`URI` is only required when the type is `SUBTITLES`, otherwise it is optional.

Fixes #42 