### PR TITLE
feat: corruption to delay HLS media manifest responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Delay Corruption:
 ```typescript
 {
     i?: number | "*",  // index of target segment in playlist. If "*", then target all segments. (Starts on 0 for HLS / 1 for MPEG-DASH)
+    l?: number | "*",  // index of ABR rung to delay media playlist. (Starts on 1 and only applicable to HLS)
     sq?: number | "*", // media sequence number of target segment in playlist. If "*", then target all segments
     rsq?: number,      // relative sequence number from where a livestream is currently at
     ms?: number,       // time to delay in milliseconds
@@ -191,7 +192,13 @@ https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/hls/proxy-master.m3
 7. LIVE: With response of status code 404 on segment with sequence number 105:
 
 ```
-https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/hls/proxy-master.m3u8?url=https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8&statusCode=[{sq:105,code:400}]
+https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/hls/proxy-master.m3u8?url=https://demo.vc.eyevinn.technology/channels/demo/master.m3u8&statusCode=[{sq:105,code:400}]
+```
+
+8. LIVE: Delay response of media manifest ladder 1 and 2 with 500 ms
+
+```
+https://chaos-proxy.prod.eyevinn.technology/api/v2/manifests/hls/proxy-master.m3u8?url=https://demo.vc.eyevinn.technology/channels/demo/master.m3u8&delay=[{l:1,ms:500},{l:2,ms:500}]
 ```
 
 ### Example corruptions on MPEG-DASH Streams

--- a/src/manifests/utils/corruptions/delay.test.ts
+++ b/src/manifests/utils/corruptions/delay.test.ts
@@ -93,7 +93,7 @@ describe('manifest.utils.corruptions.delay', () => {
       const expected = [
         {
           message:
-            "Incorrect delay query format. Either 'i' or 'sq' is required in a single query object.",
+            "Incorrect delay query format. Either 'i', 'l' or 'sq' is required in a single query object.",
           status: 400
         },
         null
@@ -131,7 +131,7 @@ describe('manifest.utils.corruptions.delay', () => {
       const expected = [
         {
           message:
-            'Incorrect delay query format. Expected format: [{i?:number, sq?:number, br?:number, ms:number}, ...n] where i and sq are mutually exclusive.',
+            'Incorrect delay query format. Expected format: [{i?:number, l?:number, sq?:number, br?:number, ms:number}, ...n] where i and sq are mutually exclusive.',
           status: 400
         },
         null
@@ -151,7 +151,7 @@ describe('manifest.utils.corruptions.delay', () => {
       const expected = [
         {
           message:
-            'Incorrect delay query format. Expected format: [{i?:number, sq?:number, br?:number, ms:number}, ...n] where i and sq are mutually exclusive.',
+            'Incorrect delay query format. Expected format: [{i?:number, l?:number, sq?:number, br?:number, ms:number}, ...n] where i and sq are mutually exclusive.',
           status: 400
         },
         null

--- a/src/manifests/utils/hlsManifestUtils.test.ts
+++ b/src/manifests/utils/hlsManifestUtils.test.ts
@@ -38,11 +38,11 @@ describe('hlsManifestTools', () => {
 #EXT-X-VERSION:3
 #EXT-X-INDEPENDENT-SEGMENTS
 #EXT-X-STREAM-INF:BANDWIDTH=4255267,AVERAGE-BANDWIDTH=4255267,CODECS="avc1.4d4032,mp4a.40.2",RESOLUTION=2560x1440,FRAME-RATE=25,AUDIO="audio",SUBTITLES="subs"
-proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_1.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D&bitrate=4255267
+proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_1.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D&bitrate=4255267&level=1
 #EXT-X-STREAM-INF:BANDWIDTH=3062896,AVERAGE-BANDWIDTH=3062896,CODECS="avc1.4d4028,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=25,AUDIO="audio",SUBTITLES="subs"
-proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_2.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D&bitrate=3062896
+proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_2.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D&bitrate=3062896&level=2
 #EXT-X-STREAM-INF:BANDWIDTH=2316761,AVERAGE-BANDWIDTH=2316761,CODECS="avc1.4d4028,mp4a.40.2",RESOLUTION=1920x1080,FRAME-RATE=25,AUDIO="audio",SUBTITLES="subs"
-proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_3.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D&bitrate=2316761
+proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_3.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D&bitrate=2316761&level=3
 
 #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",LANGUAGE="en",NAME="English stereo",CHANNELS="2",DEFAULT=YES,AUTOSELECT=YES,URI="proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_audio-en.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D"
 #EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio",LANGUAGE="sv",NAME="Swedish stereo",CHANNELS="2",DEFAULT=NO,AUTOSELECT=YES,URI="proxy-media.m3u8?url=https%3A%2F%2Fmock.mock.com%2Fstream%2Fhls%2Fmanifest_audio-sv.m3u8&statusCode=%5B%7Bi%3A0%2Ccode%3A404%7D%2C%7Bi%3A2%2Ccode%3A401%7D%5D&timeout=%5B%7Bi%3A3%7D%5D&delay=%5B%7Bi%3A2%2Cms%3A2000%7D%5D"

--- a/src/manifests/utils/hlsManifestUtils.ts
+++ b/src/manifests/utils/hlsManifestUtils.ts
@@ -83,6 +83,7 @@ export default function (): HLSManifestTools {
       const m3u: M3U = clone(originalM3U);
 
       // [Video]
+      let abrLevel = 1;
       m3u.items.StreamItem = m3u.items.StreamItem.map((streamItem) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const bitRate = (streamItem as any)?.attributes?.attributes?.bandwidth;
@@ -91,6 +92,8 @@ export default function (): HLSManifestTools {
         const urlQuery = new URLSearchParams(originalUrlQuery);
         if (bitRate) {
           urlQuery.set('bitrate', bitRate);
+          urlQuery.set('level', abrLevel.toString());
+          abrLevel++;
         }
         streamItem.set(
           'uri',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,8 @@ export type ServiceError = {
 
 export type TargetIndex = number | '*';
 
+export type TargetLevel = number;
+
 /**
  * Cherrypicking explicitly what we need to type from
  * https://github.com/Eyevinn/node-m3u8/blob/master/m3u/Item.js


### PR DESCRIPTION
Delay response of media manifest ladder 1 and 2 with 500 ms

```
/api/v2/manifests/hls/proxy-master.m3u8?url=https://demo.vc.eyevinn.technology/channels/demo/master.m3u8&delay=[{l:1,ms:500},{l:2,ms:500}]
```