### PR TITLE
fix: support manifests with Representation inside SegmentTemplate instead of media

### DIFF
--- a/src/manifests/utils/dashManifestUtils.ts
+++ b/src/manifests/utils/dashManifestUtils.ts
@@ -75,8 +75,9 @@ export default function (): DASHManifestTools {
 
       DASH_JSON.MPD.Period.map((period) => {
         period.AdaptationSet.map((adaptationSet) => {
-          if (adaptationSet.SegmentTemplate) {
-            // There should only be one segment template with this format
+          // If there is a SegmentTemplate directly in the adaptationSet there should only be one
+          // But if it has no media property it is invalid and we should try the Representation instead
+          if (adaptationSet.SegmentTemplate?.[0]?.$?.media) {
             const segmentTemplate = adaptationSet.SegmentTemplate[0];
 
             // Media attr


### PR DESCRIPTION
Fixes #50

The manifest that was used has a `<SegmentTemplate>` without a media property, but it also has a `<Representation>` containg multiple `<SegmentTemplate>`s with media properties.

I don't think is valid (our own [validator](https://github.com/Eyevinn/dash-validator-js) can't even parse it), but most players seems to support it, and we can support it as well this way.

There is a separate issue with CSP and the stream used #50, however, so this won't fox the issue for the customer. I'm looking into that one now.