### PR TITLE
feat: add support for segment templates with a width param

### DIFF
--- a/src/manifests/handlers/dash/segment.ts
+++ b/src/manifests/handlers/dash/segment.ts
@@ -40,7 +40,12 @@ export default async function dashSegmentHandler(
     const [, reqSegmentIndexStr, representationIdStr, bitrateStr] =
       pathStem.split('_');
     // Build correct Source Segment url
-    let segmentUrl = url.replace('$Number$', reqSegmentIndexStr);
+    // segment templates may contain a width parameter "$Number%0[width]d$", and then we need to zero-pad them to that length
+    let segmentUrl = url
+      .replace(/\$Number%0(\d+)d\$/, (_, width) =>
+        reqSegmentIndexStr.padStart(Number(width), '0')
+      )
+      .replace('$Number$', reqSegmentIndexStr);
     const reqSegmentIndexInt = parseInt(reqSegmentIndexStr);
     // Replace RepresentationID in url if present
     if (representationIdStr) {


### PR DESCRIPTION
See #52 (this PR fixes the known issue, but the issue was created to be ensure we are not missing support for other segment template formats)

https://ottverse.com/structure-of-an-mpeg-dash-mpd/#Segment_Templates

![image](https://github.com/Eyevinn/chaos-stream-proxy/assets/515120/071cbcc2-0f87-4e3d-a083-9601612bab42)
